### PR TITLE
Reuse built Dagster images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ a fictional DVD rental company.
 
 ```sh
 $ ./scripts/init.sh
+$ docker compose --env-file compose/.env build
 $ docker compose --env-file compose/.env up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,9 +51,11 @@ services:
       - metabase-db-password
 
   dagster-daemon:
+    image: sakila-company/dagster
     build:
       context: ./sakila_etl
       dockerfile: Dockerfile_base
+    pull_policy: never
     entrypoint: ["dagster-daemon", "run", "-w", "workspace.yaml"]
     environment:
       DAGSTER_DB_USERNAME: dagster
@@ -65,9 +67,11 @@ services:
       - dagster-db
 
   dagster-webserver:
+    image: sakila-company/dagster
     build:
       context: ./sakila_etl
       dockerfile: Dockerfile_base
+    pull_policy: never
     entrypoint:
       - dagster-webserver
       - -h
@@ -88,9 +92,11 @@ services:
       - dagster-db
 
   dagster-code-sakila_etl:
+    image: sakila-company/dagster-worker
     build:
       context: ./sakila_etl
       dockerfile: Dockerfile
+    pull_policy: never
     entrypoint:
       - "dagster"
       - "api"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -109,4 +109,5 @@ DAGSTER_CLICKHOUSE_PASSWORD=$ANALYTICS_DWH_PASSWORD
 EOF
 echo ..done
 
-echo "Run docker compose --env-file compose/.env up to start the project"
+echo "Run docker compose --env-file compose/.env build"
+echo "and docker compose --env-file compose/.env up to start the project"


### PR DESCRIPTION
This names images used by Dagster services explicitly to enable reusing.
This helps with image registry's storage usage.