### PR TITLE
Fix dagster code server failing to start

### DIFF
--- a/sakila_etl/sakila_etl/dbt_assets.py
+++ b/sakila_etl/sakila_etl/dbt_assets.py
@@ -9,9 +9,9 @@ from dagster_dbt import (
     DbtProject,
 )
 
-
+# TODO: Compile dbt project during CD
 dbt_project = DbtProject(project_dir=Path(__file__).parent / "dbt_project")
-dbt_project.prepare_if_dev()
+dbt_project.preparer.prepare(dbt_project)
 
 
 class CustomDagsterDbtTranslator(DagsterDbtTranslator):


### PR DESCRIPTION
Dagster code server failed to start because its dbt project was not compiled.
This works around by always compiling it on loading regardless of environment.