### PR TITLE
Add example secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 .vscode
 
-compose/**/secrets/
+# Service secrets
+compose/app-db/secrets/db_password.txt
+compose/dagster/secrets/dbt_profiles.yml
+compose/dagster/secrets/dlt_secrets.toml
+compose/dagster-db/secrets/db_password.txt
+compose/metabase-db/secrets/db_password.txt
+
 compose/.env*
 compose/**/LICENSE*
 compose/app-db/docker-entrypoint-initdb.d/pagila-*.sql

--- a/compose/app-db/secrets/db_password.txt.example
+++ b/compose/app-db/secrets/db_password.txt.example
@@ -1,0 +1,1 @@
+VerySecureAppDbPassword

--- a/compose/dagster-db/secrets/db_password.txt.example
+++ b/compose/dagster-db/secrets/db_password.txt.example
@@ -1,0 +1,1 @@
+VerySecureDagsterDbPassword

--- a/compose/dagster/secrets/dbt_profiles.yml.example
+++ b/compose/dagster/secrets/dbt_profiles.yml.example
@@ -1,0 +1,24 @@
+sakila_dwh:
+  target: default
+  outputs:
+    default:
+      type: clickhouse
+      schema: analytics
+      user: admin
+      password: "VerySecureDwhPassword"
+      #optional fields
+      driver: native
+      port: 9000
+      host: analytics-dwh
+      retries: 1
+      verify: False
+      secure: False
+      connect_timeout: 10
+      send_receive_timeout: 300
+      sync_request_timeout: 5
+      # compression: False
+      compress_block_size: 1048576
+      # database_engine: <db_engine>
+      check_exchange: True
+      # use_lw_deletes: False
+      # custom_settings: <empty>

--- a/compose/dagster/secrets/dlt_secrets.toml.example
+++ b/compose/dagster/secrets/dlt_secrets.toml.example
@@ -1,0 +1,16 @@
+[sources.sql_database.pagila.credentials]
+drivername = "postgresql+psycopg2"
+host = "app-db"
+port = "5432"
+database = "pagila"
+username = "postgres"
+password = "VerySecureAppDbPassword"
+
+[analytics_dwh__pagila.destination.clickhouse.credentials]
+host = "analytics-dwh"
+database = "raw_pagila"
+username = "admin"
+password = "VerySecureDwhPassword"
+port = 9000
+http_port = 8123
+secure = 0

--- a/compose/metabase-db/secrets/db_password.txt.example
+++ b/compose/metabase-db/secrets/db_password.txt.example
@@ -1,0 +1,1 @@
+VerySecureMetabaseDbPassword


### PR DESCRIPTION
Add example secrets so that they can be used as references of what actual secret files look like
without running a whole initialization script again.